### PR TITLE
Suppressed 'Missing XML comment' warnings 

### DIFF
--- a/src/PaymentGateway.Api/PaymentGateway.Api.csproj
+++ b/src/PaymentGateway.Api/PaymentGateway.Api.csproj
@@ -7,6 +7,14 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;CS1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;CS1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
The xml documentation feature is only being used for Open API docs so its unnecessary to document every method.