### PR TITLE
Fix an error when the card number is too short

### DIFF
--- a/src/PaymentGateway.Api/Infrastructure/Translators/CardPaymentToGetPaymentResponseTranslator.cs
+++ b/src/PaymentGateway.Api/Infrastructure/Translators/CardPaymentToGetPaymentResponseTranslator.cs
@@ -10,7 +10,7 @@ namespace PaymentGateway.Api.Infrastructure.Translators
             return new GetPaymentResponse
             {
                 Id = payment.Id,
-                CardNumberLastFour = payment.CardNumber.Substring(payment.CardNumber.Length - 4, 4),
+                CardNumberLastFour = payment.CardNumber.Length > 4 ? payment.CardNumber.Substring(payment.CardNumber.Length - 4, 4) : payment.CardNumber,
                 Amount = payment.Amount,
                 Currency = payment.Currency,
                 ExpiryMonth = payment.ExpiryMonth,

--- a/src/PaymentGateway.Api/Infrastructure/Translators/CardPaymentToPostPaymentResponseTranslator.cs
+++ b/src/PaymentGateway.Api/Infrastructure/Translators/CardPaymentToPostPaymentResponseTranslator.cs
@@ -11,7 +11,7 @@ namespace PaymentGateway.Api.Infrastructure.Translators
             {
                 Id = cardPayment.Id,
                 Status = cardPayment.Status,
-                CardNumberLastFour = cardPayment.CardNumber.Substring(cardPayment.CardNumber.Length - 4, 4),
+                CardNumberLastFour = cardPayment.CardNumber.Length > 4 ? cardPayment.CardNumber.Substring(cardPayment.CardNumber.Length - 4, 4) : cardPayment.CardNumber,
                 ExpiryMonth = cardPayment.ExpiryMonth,
                 ExpiryYear = cardPayment.ExpiryYear,
                 Amount = cardPayment.Amount,

--- a/test/PaymentGateway.Api.Tests/Unit/Infrastructure/Translators/CardPaymentToGetPaymentResponseTranslatorTests.cs
+++ b/test/PaymentGateway.Api.Tests/Unit/Infrastructure/Translators/CardPaymentToGetPaymentResponseTranslatorTests.cs
@@ -39,5 +39,32 @@ namespace PaymentGateway.Api.Tests.Unit.Infrastructure.Translators
 
             Assert.Equal(PaymentStatus.Authorized, acquiringBankPaymentRequest.Status);
         }
+        
+        [Fact]
+        public void ToGetPaymentResponse_InvalidCardNumber_TranslatesToResponce()
+        {
+            //Arrange
+            var cardPayment = new CardPayment
+            {
+                Id = Guid.NewGuid(),
+
+                CardNumber = "22",
+                Cvv = "123",
+                ExpiryMonth = 4,
+                ExpiryYear = 2025,
+
+                Amount = 100,
+                Currency = "GBP",
+
+                AuthorizationCode = Guid.NewGuid(),
+                Status = PaymentStatus.Authorized,
+            };
+
+            //Act
+            var acquiringBankPaymentRequest = cardPayment.ToGetPaymentResponse();
+
+            //Assert
+            Assert.Equal("22", acquiringBankPaymentRequest.CardNumberLastFour);
+        }
     }
 }

--- a/test/PaymentGateway.Api.Tests/Unit/Infrastructure/Translators/CardPaymentToPostPaymentResponseTranslatorTests.cs
+++ b/test/PaymentGateway.Api.Tests/Unit/Infrastructure/Translators/CardPaymentToPostPaymentResponseTranslatorTests.cs
@@ -41,5 +41,32 @@ namespace PaymentGateway.Api.Tests.Unit.Infrastructure.Translators
             Assert.Equal(100, postPaymentResponse.Amount);
             Assert.Equal("GBP", postPaymentResponse.Currency);
         }
+        
+        [Fact]
+        public void ToPostPaymentResponse_InvalidCardNumber_TranslatesToResponse()
+        {
+            //Arrange
+            var cardPayment = new CardPayment
+            {
+                Id = Guid.NewGuid(),
+
+                CardNumber = "22",
+                Cvv = "123",
+                ExpiryMonth = 4,
+                ExpiryYear = 2025,
+
+                Amount = 100,
+                Currency = "GBP",
+
+                AuthorizationCode = Guid.NewGuid(),
+                Status = PaymentStatus.Authorized,
+            };
+
+            //Act
+            var postPaymentResponse = cardPayment.ToPostPaymentResponse();
+
+            //Assert
+            Assert.Equal("22", postPaymentResponse.CardNumberLastFour);
+        }
     }
 }


### PR DESCRIPTION
Added test to ensure the card number is greater than 4 digits before truncating in both translators.